### PR TITLE
perf(persistence): optimize price lookup with JOIN FETCH and composit…

### DIFF
--- a/src/main/java/com/inditex/inditex_iot_backend/adapter/out/persistence/JpaPriceRepository.java
+++ b/src/main/java/com/inditex/inditex_iot_backend/adapter/out/persistence/JpaPriceRepository.java
@@ -12,6 +12,7 @@ public interface JpaPriceRepository extends JpaRepository<PriceJpaEntity, Long> 
 
   @Query("""
           select p from PriceJpaEntity p
+          join fetch p.brand
           where p.brand.id = :brandId
             and p.productId = :productId
             and :when between p.startDate and p.endDate

--- a/src/main/java/com/inditex/inditex_iot_backend/adapter/out/persistence/PriceJpaEntity.java
+++ b/src/main/java/com/inditex/inditex_iot_backend/adapter/out/persistence/PriceJpaEntity.java
@@ -6,9 +6,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "prices", indexes = {
-        @Index(name = "ix_brand_product", columnList = "brand_id, product_id"),
-        @Index(name = "ix_dates", columnList = "start_date, end_date"),
-        @Index(name = "ix_priority", columnList = "priority")
+        // Optimized index for filter and sorting
+        @Index(name = "ix_aplicable_price", columnList = "brand_id, product_id, start_date, end_date, priority desc, price_list desc")
 })
 public class PriceJpaEntity {
     @Id

--- a/src/main/java/com/inditex/inditex_iot_backend/adapter/out/persistence/PricePersistenceAdapter.java
+++ b/src/main/java/com/inditex/inditex_iot_backend/adapter/out/persistence/PricePersistenceAdapter.java
@@ -19,6 +19,7 @@ public class PricePersistenceAdapter implements LoadPricesPort {
 
     @Override
     public List<Price> loadPrices(int brandId, long productId, LocalDateTime applicationDate) {
+        // this line ensures that the query only brings the most prioritary record
         return repo.findApplicable(brandId, productId, applicationDate, PageRequest.of(0, 1))
                 .stream()
                 .findFirst()


### PR DESCRIPTION
…e index

Optimizes the efficiency of retrieving the highest priority through two changes:

1. Modifies query in JpaPriceRepository to use JOIN FETCH p.brand. This eliminates any risk of an N+1 query when accessing the brand ID and ensures the Brand entity is loaded in a single database round trip.

2. Creates an optimized composite index in PriceJpaEntity.